### PR TITLE
refactor sphinx plugin

### DIFF
--- a/dargs/sphinx.py
+++ b/dargs/sphinx.py
@@ -61,7 +61,6 @@ class DargsDirective(Directive):
             if not isinstance(argument, (Argument, Variant)):
                 raise RuntimeError("The function doesn't return Argument")
             rst = argument.gen_doc(make_anchor=True, make_link=True)
-            print(rst)
             self.state_machine.insert_input(rst.split("\n"), "%s:%s" %(module_name, attr_name))
         return items
 

--- a/dargs/sphinx.py
+++ b/dargs/sphinx.py
@@ -56,13 +56,12 @@ class DargsDirective(Directive):
         if not isinstance(arguments, (list, tuple)):
             arguments = [arguments]
 
-        items = []
         for argument in arguments:
             if not isinstance(argument, (Argument, Variant)):
                 raise RuntimeError("The function doesn't return Argument")
             rst = argument.gen_doc(make_anchor=True, make_link=True)
             self.state_machine.insert_input(rst.split("\n"), "%s:%s" %(module_name, attr_name))
-        return items
+        return []
 
 
 def setup(app):


### PR DESCRIPTION
Change the way to generate documentation with fewer codes. This does not have any changes in the output.
Also, add more sub_items/sub_variants displayed in the dargs documentation, for test purpose.