### PR TITLE
fix compatibility with Python 3.12

### DIFF
--- a/dargs/dargs.py
+++ b/dargs/dargs.py
@@ -900,7 +900,7 @@ class Variant:
             realdoc,
             targetdoc,
         ]
-        return "\n".join(filter(None.__ne__, allparts))
+        return "\n".join([x for x in allparts if x is not None])
 
     def _make_cpath(
         self, cname: str, path: Optional[List[str]] = None, showflag: bool = False


### PR DESCRIPTION
`None.__ne__` does not work in Python 3.12 anymore.