### PR TITLE
fix: strip func in cli

### DIFF
--- a/dargs/cli.py
+++ b/dargs/cli.py
@@ -90,7 +90,7 @@ def check_cli(
     dict
         normalized data
     """
-    module_name, attr_name = func.rsplit(".", 1)
+    module_name, attr_name = func.strip().rsplit(".", 1)
     try:
         mod = __import__(module_name, globals(), locals(), [attr_name])
     except ImportError as e:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
    - Improved handling of input strings in the CLI by trimming spaces before parsing. This prevents errors due to unexpected whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->