### PR TITLE
docs: fix referenced argument func

### DIFF
--- a/docs/sphinx.rst
+++ b/docs/sphinx.rst
@@ -16,13 +16,13 @@ Then `dargs` directive will be enabled:
 
     .. dargs::
        :module: dargs._test
-       :func: test_argument
+       :func: test_arguments
 
-where `test_argument` returns an :class:`Argument <dargs.Argument>`. The documentation will be rendered as:
+where `test_arguments` returns an :class:`Argument <dargs.Argument>`. The documentation will be rendered as:
 
 .. dargs::
    :module: dargs._test
-   :func: test_argument
+   :func: test_arguments
 
 A :class:`list` of :class:`Argument <dargs.Argument>` is also accepted.
 
@@ -37,7 +37,7 @@ To write Markdown files with `MyST-Parser <https://github.com/executablebooks/My
     ```{eval-rst}
     .. dargs::
        :module: dargs._test
-       :func: test_argument
+       :func: test_arguments
     ```
 
 Cross-referencing Arguments

--- a/docs/sphinx.rst
+++ b/docs/sphinx.rst
@@ -27,8 +27,8 @@ where `test_argument` returns an :class:`Argument <dargs.Argument>`. The documen
 A :class:`list` of :class:`Argument <dargs.Argument>` is also accepted.
 
 .. dargs::
-   :module: dargs.sphinx
-   :func: test_argument
+   :module: dargs.test
+   :func: test_arguments
 
 To write Markdown files with `MyST-Parser <https://github.com/executablebooks/MyST-parser>`_, one can use:
 

--- a/docs/sphinx.rst
+++ b/docs/sphinx.rst
@@ -27,7 +27,7 @@ where `test_argument` returns an :class:`Argument <dargs.Argument>`. The documen
 A :class:`list` of :class:`Argument <dargs.Argument>` is also accepted.
 
 .. dargs::
-   :module: dargs.test
+   :module: dargs._test
    :func: test_arguments
 
 To write Markdown files with `MyST-Parser <https://github.com/executablebooks/MyST-parser>`_, one can use:

--- a/docs/sphinx.rst
+++ b/docs/sphinx.rst
@@ -15,20 +15,20 @@ Then `dargs` directive will be enabled:
 .. code-block:: rst
 
     .. dargs::
-       :module: dargs._test
-       :func: test_arguments
+       :module: dargs.sphinx
+       :func: test_argument
 
-where `test_arguments` returns an :class:`Argument <dargs.Argument>`. The documentation will be rendered as:
+where `test_argument` returns an :class:`Argument <dargs.Argument>`. The documentation will be rendered as:
 
 .. dargs::
-   :module: dargs._test
-   :func: test_arguments
+   :module: dargs.sphinx
+   :func: test_argument
 
 A :class:`list` of :class:`Argument <dargs.Argument>` is also accepted.
 
 .. dargs::
-   :module: dargs._test
-   :func: test_arguments
+   :module: dargs.sphinx
+   :func: test_argument
 
 To write Markdown files with `MyST-Parser <https://github.com/executablebooks/MyST-parser>`_, one can use:
 
@@ -36,8 +36,8 @@ To write Markdown files with `MyST-Parser <https://github.com/executablebooks/My
 
     ```{eval-rst}
     .. dargs::
-       :module: dargs._test
-       :func: test_arguments
+       :module: dargs.sphinx
+       :func: test_argument
     ```
 
 Cross-referencing Arguments

--- a/docs/sphinx.rst
+++ b/docs/sphinx.rst
@@ -16,13 +16,13 @@ Then `dargs` directive will be enabled:
 
     .. dargs::
        :module: dargs.sphinx
-       :func: test_argument
+       :func: _test_argument
 
-where `test_argument` returns an :class:`Argument <dargs.Argument>`. The documentation will be rendered as:
+where `_test_argument` returns an :class:`Argument <dargs.Argument>`. The documentation will be rendered as:
 
 .. dargs::
    :module: dargs.sphinx
-   :func: test_argument
+   :func: _test_argument
 
 A :class:`list` of :class:`Argument <dargs.Argument>` is also accepted.
 
@@ -37,7 +37,7 @@ To write Markdown files with `MyST-Parser <https://github.com/executablebooks/My
     ```{eval-rst}
     .. dargs::
        :module: dargs.sphinx
-       :func: test_argument
+       :func: _test_argument
     ```
 
 Cross-referencing Arguments


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation to reflect the new function name `test_arguments` instead of `test_argument` for clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->