### PR TITLE
fix: throw meaningful error message for wrong dtype of repeated dict

### DIFF
--- a/dargs/dargs.py
+++ b/dargs/dargs.py
@@ -391,7 +391,12 @@ class Argument:
         variant_hook: HookVrntType = _DUMMYHOOK,
         path: list[str] | None = None,
     ):
-        assert isinstance(value, dict)
+        if not isinstance(value, dict):
+            raise ArgumentTypeError(
+                path,
+                f"key `{path[-1]}` gets wrong value type, "
+                f"requires dict but {type(value).__name__} is given",
+            )
         if path is None:
             path = [self.name]
         sub_hook(self, value, path)

--- a/dargs/dargs.py
+++ b/dargs/dargs.py
@@ -391,14 +391,14 @@ class Argument:
         variant_hook: HookVrntType = _DUMMYHOOK,
         path: list[str] | None = None,
     ):
+        if path is None:
+            path = [self.name]
         if not isinstance(value, dict):
             raise ArgumentTypeError(
                 path,
                 f"key `{path[-1]}` gets wrong value type, "
                 f"requires dict but {type(value).__name__} is given",
             )
-        if path is None:
-            path = [self.name]
         sub_hook(self, value, path)
         for subvrnt in self.sub_variants.values():
             variant_hook(subvrnt, value, path)

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -156,6 +156,14 @@ class TestChecker(unittest.TestCase):
         }
         with self.assertRaises(ArgumentTypeError):
             ca.check(err_dict2)
+        err_dict3 = {
+            "base": {
+                "item1": {"sub1": 10, "sub2": "hello"},
+                "item2": "not_a_dict_error",
+            }
+        }
+        with self.assertRaises(ArgumentTypeError):
+            ca.check(err_dict3)
 
     def test_sub_variants(self):
         ca = Argument(


### PR DESCRIPTION
Fix #80.