### PR TITLE
feat: show doc of variants after links

### DIFF
--- a/dargs/dargs.py
+++ b/dargs/dargs.py
@@ -952,6 +952,13 @@ class Variant:
         choicedoc = indent("| possible choices: " + ", ".join(l_choice), INDENT)
         realdoc = indent(self.doc + "\n", INDENT) if self.doc else None
         anchor = make_rst_refid(arg_path) if kwargs.get("make_anchor") else None
+        abstractdoc = "\n".join(
+            [
+                f"* {ll}: {cc.doc}"
+                for ll, cc in zip(l_choice, self.choice_dict.values())
+                if cc.doc
+            ]
+        )
         allparts = [
             anchor,
             headdoc,
@@ -960,6 +967,9 @@ class Variant:
             choicedoc,
             "",
             realdoc,
+            "",
+            abstractdoc,
+            "",
             targetdoc,
         ]
         return "\n".join([x for x in allparts if x is not None])

--- a/dargs/dargs.py
+++ b/dargs/dargs.py
@@ -952,12 +952,15 @@ class Variant:
         choicedoc = indent("| possible choices: " + ", ".join(l_choice), INDENT)
         realdoc = indent(self.doc + "\n", INDENT) if self.doc else None
         anchor = make_rst_refid(arg_path) if kwargs.get("make_anchor") else None
-        abstractdoc = "\n".join(
-            [
-                f"* {ll}: {cc.doc}"
-                for ll, cc in zip(l_choice, self.choice_dict.values())
-                if cc.doc
-            ]
+        abstractdoc = indent(
+            "\n".join(
+                [
+                    f"* {ll}: {cc.doc}"
+                    for ll, cc in zip(l_choice, self.choice_dict.values())
+                    if cc.doc
+                ]
+            ),
+            INDENT,
         )
         allparts = [
             anchor,


### PR DESCRIPTION
This addresses https://github.com/deepmodeling/deepmd-kit/pull/4239#discussion_r1811764692. The doc of different variants should be generated automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced documentation generation for the `Variant` class, now including a summary of choices available.
- **Bug Fixes**
	- Updated the `gen_doc_flag` method to ensure accurate output reflecting new documentation capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->