### PR TITLE
fix: fix html escape in the notebook

### DIFF
--- a/dargs/notebook.py
+++ b/dargs/notebook.py
@@ -19,6 +19,7 @@ Examples
 
 from __future__ import annotations
 
+import html
 import json
 import re
 from typing import Any
@@ -249,7 +250,7 @@ class ArgumentData:
                 else:
                     raise ValueError(f"Unknown type: {type(self.arg)}")
 
-                doc_body = self.arg.doc.strip()
+                doc_body = html.escape(self.arg.doc.strip())
                 if doc_body:
                     buff.append("<hr/>")
                 doc_body = re.sub(r"""\n+""", "\n", doc_body)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced HTML output handling for JSON data in Jupyter Notebooks, ensuring special HTML characters in documentation are properly escaped.
  
- **Bug Fixes**
	- Improved safety and correctness of rendered HTML output without altering existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->