### PR TITLE
Raise ArgumentTypeError for non-string variant choices

### DIFF
--- a/dargs/dargs.py
+++ b/dargs/dargs.py
@@ -898,6 +898,14 @@ class Variant:
     def get_choice(self, argdict: dict, path: list[str] | None = None) -> Argument:
         if self.flag_name in argdict:
             tag = argdict[self.flag_name]
+            choices = [*self.choice_dict, *self.choice_alias]
+            if not isinstance(tag, str):
+                raise ArgumentTypeError(
+                    path,
+                    f"key `{self.flag_name}` gets wrong value type, requires <str> "
+                    f"but {type(tag).__name__} is given; "
+                    f"expected choices are <{'|'.join(choices)}>",
+                )
             if tag in self.choice_dict:
                 return self.choice_dict[tag]
             elif tag in self.choice_alias:
@@ -906,10 +914,7 @@ class Variant:
                 raise ArgumentValueError(
                     path,
                     f"get invalid choice `{tag}` for flag key `{self.flag_name}`."
-                    + did_you_mean(
-                        tag,
-                        list(self.choice_dict.keys()) + list(self.choice_alias.keys()),
-                    ),
+                    + did_you_mean(tag, choices),
                 )
         elif self.optional:
             return self.choice_dict[self.default_tag]
@@ -934,7 +939,11 @@ class Variant:
     ) -> None:
         if self.flag_name in argdict:
             tag = argdict[self.flag_name]
-            if tag not in self.choice_dict and tag in self.choice_alias:
+            if (
+                isinstance(tag, str)
+                and tag not in self.choice_dict
+                and tag in self.choice_alias
+            ):
                 argdict[self.flag_name] = self.choice_alias[tag]
 
     # above are traversing part

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -165,6 +165,27 @@ class TestChecker(unittest.TestCase):
         with self.assertRaises(ArgumentTypeError):
             ca.check(err_dict3)
 
+    def test_variant_choice_type(self) -> None:
+        ca = Argument(
+            "base",
+            dict,
+            sub_variants=[
+                Variant("kind", [Argument("alpha", dict, alias=["a"])])
+            ],
+        )
+        for tag in ([], {}, 1, None):
+            with self.subTest(tag=tag):
+                with self.assertRaises(ArgumentTypeError) as cm:
+                    ca.normalize_value({"kind": tag})
+                self.assertEqual(cm.exception.path, "")
+                self.assertIn("requires <str>", str(cm.exception))
+                self.assertIn("expected choices are <alpha|a>", str(cm.exception))
+
+        self.assertEqual(ca.normalize_value({"kind": "a"}), {"kind": "alpha"})
+        with self.assertRaises(ArgumentValueError) as cm:
+            ca.normalize_value({"kind": "alpah"})
+        self.assertIn("Did you mean: alpha?", str(cm.exception))
+
     def test_sub_variants(self) -> None:
         ca = Argument(
             "base",

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -169,9 +169,7 @@ class TestChecker(unittest.TestCase):
         ca = Argument(
             "base",
             dict,
-            sub_variants=[
-                Variant("kind", [Argument("alpha", dict, alias=["a"])])
-            ],
+            sub_variants=[Variant("kind", [Argument("alpha", dict, alias=["a"])])],
         )
         for tag in ([], {}, 1, None):
             with self.subTest(tag=tag):


### PR DESCRIPTION
## Summary

- validate a variant tag's type before alias dictionary membership or spelling suggestions
- raise the structured `ArgumentTypeError` for list, mapping, numeric, and null tags instead of leaking raw `TypeError`
- preserve alias normalization and `Did you mean` behavior for string values

Fixes #119.

## Validation

- focused regression: 1 passed on the exact upstream base and patch
- adjacent checker tests: 13 passed on the exact upstream base and patch
- full suite: 50 passed on the exact upstream base and patch
- `git diff --check`, Python AST checks, and a bounded manual security review passed in the publication worktree
- the current publication environment could not recollect pytest because `typeguard` is not installed; no dependencies were installed for this submission

## AI assistance disclosure

This change was prepared and tested with OpenAI Codex. It is intentionally opened as a Draft for maintainer review. No automated issue/PR comments or Ready transition will be made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for variant choices, including clearer errors when values use an unsupported type.
  * Enhanced suggestions for misspelled choice tags.
  * Ensured aliases consistently resolve to their corresponding canonical choices.

* **Tests**
  * Added coverage for invalid types, aliases, and misspelled choice suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->